### PR TITLE
Add required dbus-python package for ipa-client.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Jan Pazdziora
 RUN yum swap -y -- remove fakesystemd -- install systemd systemd-libs && yum clean all
 
 # Install FreeIPA client
-RUN yum install -y ipa-client perl 'perl(Data::Dumper)' 'perl(Time::HiRes)' && yum clean all
+RUN yum install -y ipa-client dbus-python perl 'perl(Data::Dumper)' 'perl(Time::HiRes)' && yum clean all
 
 ADD dbus.service /etc/systemd/system/dbus.service
 RUN ln -sf dbus.service /etc/systemd/system/messagebus.service


### PR DESCRIPTION
Running a freeipa client container using the centos-7-client branch
fails with the following error:

    $ docker run -h example.host.com -ti --link ipa-master:ipa freeipa-client
    There was a problem importing one of the required Python modules. The
    error was:

    No module named dbus

Possibly related to the following bug?:

https://fedorahosted.org/freeipa/ticket/4863

This commit adds the dbus-python package to the Dockerfile which fixes
the error.

Looks like this is fixed in freeipa 4.1, but not in the upstream centos7
packages yet:

https://git.fedorahosted.org/cgit/freeipa.git/commit/?id=f5352a8f2f777dce3bf91ac63e04e75532053762