### PR TITLE
Fix missing freeipa-server-dns package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Jan Pazdziora
 RUN curl -o /etc/yum.repos.d/mkosek-freeipa-4.2-fedora-22.repo https://copr.fedoraproject.org/coprs/mkosek/freeipa-4.2/repo/fedora-22/mkosek-freeipa-4.2-fedora-22.repo
 
 # Install FreeIPA server
-RUN mkdir -p /run/lock ; dnf install -y freeipa-server bind bind-dyndb-ldap perl && dnf clean all
+RUN mkdir -p /run/lock ; dnf install -y freeipa-server freeipa-server-dns bind bind-dyndb-ldap perl && dnf clean all
 
 ADD dbus.service /etc/systemd/system/dbus.service
 RUN ln -sf dbus.service /etc/systemd/system/messagebus.service


### PR DESCRIPTION
It looks like the default configuration now requires the freeipa-server-dns package to configure properly.