### PR TITLE
Modifications to support rolekit deployment

### DIFF
--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -269,6 +269,12 @@ else
 		cp /etc/volume-version /data/volume-version
 		update_server_ip_address
 		echo "FreeIPA server configured."
+		if [ -n $JUST_INIT ] ; then
+			# If JUST_INIT is not empty, then we were asked to just
+			# run the initial setup and return success or failure.
+			# Since we've succeeded here, return 0
+			exit 0
+		fi
 	else
 		ret=$?
 		echo "FreeIPA server configuration failed."

--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -213,15 +213,6 @@ else
 
 	REALM=${DOMAIN^^}
 
-	if [ -z "$FORWARDER" ] ; then
-		FORWARDER=$( awk '$1 == "nameserver" { print $2; exit }' /etc/resolv.conf )
-	fi
-	if [ "$FORWARDER" == '127.0.0.1' ] ; then
-		FORWARDER=--no-forwarders
-	else
-		FORWARDER=--forwarder=$FORWARDER
-	fi
-
 	if [ "$CAN_EDIT_RESOLV_CONF" == "0" ] ; then
 		find /usr -name bindinstance.py | xargs sed -i '/changing resolv.conf to point to ourselves/s/^/#/'
 	fi
@@ -255,7 +246,6 @@ else
 			fi
 			echo "-r $REALM"
 		fi
-		echo "--setup-dns $FORWARDER"
 		) | xargs $RUN_CMD -U $IPA_SERVER_INSTALL_OPTS ; then
 		sed -i 's/default_ccache_name/# default_ccache_name/' /data/etc/krb5.conf
 		cp -f /etc/resolv.conf /data/etc/resolv.conf.ipa


### PR DESCRIPTION
There are special cases like rolekit where we want to be able to determine whether the initial setup of FreeIPA succeeded before continuing with processing or providing feedback to the user. This allows us to run the `ipa-server-configure-first` routine in the container and get a success-or-failure result back, rather than leaving the successful initialization running indefinitely.

Additionally, as we discussed on IRC last week, using the `$FORWARDERS` variable to set up DNS is problematic at best. The other patch here just removes that entirely so that we will rely on the `ipa-replica-install-options` file for this information.