### PR TITLE
Allow '--realm' to be specified in install options

### DIFF
--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -253,7 +253,8 @@ else
 					grep '^--ds-password=' /data/ipa-server-install-options | xargs echo -- | sed 's/^-- --ds-password=//' > /data/ds-master-password
 				fi
 			fi
-			echo "-r $REALM"
+			grep -q '^--realm=' /data/ipa-server-install-options || \
+			    echo "-r $REALM"
 		fi
 		echo "--setup-dns $FORWARDER"
 		) | xargs $RUN_CMD -U $IPA_SERVER_INSTALL_OPTS ; then


### PR DESCRIPTION
Allow a custom kerberos realm to be specified in
`ipa-server-install-options` with the `--realm` argument.

This can be useful when configuring a kerberos realm different from
the IPA host's domain name; e.g. the IPA server is
`ipa.int.example.com`, but the kerberos realm is `EXAMPLE.COM`