### PR TITLE
cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,60 +1,61 @@
 # Clone from the Fedora 23 image
 FROM fedora:23
-
 MAINTAINER Jan Pazdziora
+FROM centos:7
 
-RUN mkdir -p /run/lock && dnf install -y freeipa-server freeipa-server-dns bind bind-dyndb-ldap && dnf clean all
+RUN yum install -y \
+	bind \
+	bind-dyndb-ldap \
+	ipa-server \
+	ipa-server-dns \
+	systemd \
+	&& ( \
+		cd /lib/systemd/system/sysinit.target.wants/; \
+		for i in *; do \
+			if [ "$i" != "systemd-tmpfiles-setup.service" ]; then \
+				rm -f $i; \
+			fi \
+		done \
+	) \
+	&& rm -f /lib/systemd/system/multi-user.target.wants/* \
+	&& rm -f /etc/systemd/system/*.wants/* \
+	&& rm -f /lib/systemd/system/local-fs.target.wants/* \
+	&& rm -f /lib/systemd/system/sockets.target.wants/*udev* \
+	&& rm -f /lib/systemd/system/sockets.target.wants/*initctl* \
+	&& rm -f /lib/systemd/system/anaconda.target.wants/* \
+	&& rm -f /lib/systemd/system/basic.target.wants/* \
+	&& rm -f /lib/systemd/system/graphical.target.wants/* \
+	&& ln -vf /lib/systemd/system/multi-user.target /lib/systemd/system/default.target
 
-# Workaround https://fedorahosted.org/spin-kickstarts/ticket/60
-RUN [ -L /etc/systemd/system/syslog.service ] && ! [ -f /etc/systemd/system/syslog.service ] && rm -f /etc/systemd/system/syslog.service
+ENV TERM xterm
+ENV LANG en_US.UTF-8
 
-RUN echo 'd0a98590c74bfe36af0ce006f7b25fa60246aecb /etc/tmpfiles.d/opendnssec.conf' | sha1sum --quiet -c && mv -v /etc/tmpfiles.d/opendnssec.conf /usr/lib/tmpfiles.d/opendnssec.conf
-RUN echo '0b6f62258de66f74328b0cf45cc937fae6a30e62 /etc/systemd/system/dbus.service' | sha1sum --quiet -c && rm -vf /etc/systemd/system/dbus.service
-RUN echo '5a70f1f3db0608c156d5b6629d4cbc3b304fc045 /etc/systemd/system/sssd.service.d/journal.conf' | sha1sum --quiet -c && rm -vf /etc/systemd/system/sssd.service.d/journal.conf
-RUN find /etc/systemd/system/* '!' -name '*.wants' | xargs rm -rvf
-RUN for i in basic.target sysinit.target network.service netconsole.service ; do rm -f /usr/lib/systemd/system/$i && ln -s /dev/null /usr/lib/systemd/system/$i ; done
-
-RUN echo LANG=C > /etc/locale.conf
-
-RUN /sbin/ldconfig -X
+# systemd needs a different stop signal
+STOPSIGNAL SIGRTMIN+3
 
 COPY init-data ipa-server-configure-first ipa-server-status-check exit-with-status ipa-volume-upgrade-* /usr/sbin/
 RUN chmod -v +x /usr/sbin/init-data /usr/sbin/ipa-server-configure-first /usr/sbin/ipa-server-status-check /usr/sbin/exit-with-status /usr/sbin/ipa-volume-upgrade-*
-COPY container-ipa.target ipa-server-configure-first.service ipa-server-upgrade.service ipa-server-update-self-ip-address.service /usr/lib/systemd/system/
-RUN rmdir -v /etc/systemd/system/multi-user.target.wants \
-	&& mkdir /etc/systemd/system/container-ipa.target.wants \
-	&& ln -s /etc/systemd/system/container-ipa.target.wants /etc/systemd/system/multi-user.target.wants
+COPY ipa-server-configure-first.service ipa-server-upgrade.service ipa-server-update-self-ip-address.service /usr/lib/systemd/system/
 
-RUN systemctl set-default container-ipa.target
 RUN systemctl enable ipa-server-configure-first.service
-
-RUN mkdir -p /usr/lib/systemd/system/systemd-poweroff.service.d && ( echo '[Service]' ; echo 'ExecStartPre=/usr/bin/systemctl switch-root /usr /sbin/exit-with-status' ) > /usr/lib/systemd/system/systemd-poweroff.service.d/exit-via-chroot.conf
 
 RUN groupadd -g 389 dirsrv ; useradd -u 389 -g 389 -c 'DS System User' -d '/var/lib/dirsrv' --no-create-home -s '/sbin/nologin' dirsrv
 RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -d '/var/lib/kdcproxy' -s '/sbin/nologin' kdcproxy
 
 COPY volume-data-list volume-data-mv-list volume-data-autoupdate /etc/
 RUN set -e ; cd / ; mkdir /data-template ; cat /etc/volume-data-list | while read i ; do echo $i ; if [ -e $i ] ; then tar cf - .$i | ( cd /data-template && tar xf - ) ; fi ; mkdir -p $( dirname $i ) ; if [ "$i" == /var/log/ ] ; then mv /var/log /var/log-removed ; else rm -rf $i ; fi ; ln -sf /data${i%/} ${i%/} ; done
-RUN rm -rf /var/log-removed
-RUN sed -i 's!^d /var/log.*!L /var/log - - - - /data/var/log!' /usr/lib/tmpfiles.d/var.conf
-# Workaround 1286602
-RUN mv /usr/lib/tmpfiles.d/journal-nocow.conf /usr/lib/tmpfiles.d/journal-nocow.conf.disabled
-RUN mv /data-template/etc/dirsrv/schema /usr/share/dirsrv/schema && ln -s /usr/share/dirsrv/schema /data-template/etc/dirsrv/schema
-RUN rm -f /data-template/var/lib/systemd/random-seed
-RUN echo 1.1 > /etc/volume-version
-
-RUN for i in /usr/lib/systemd/system/*-domainname.service ; do sed -i 's#^ExecStart=/#ExecStart=-/#' $i ; done
-
-RUN sed -i 's/^UUID=/# UUID=/' /etc/fstab
+RUN rm -rf /var/log-removed \
+	&& sed -i 's!^d /var/log.*!L /var/log - - - - /data/var/log!' /usr/lib/tmpfiles.d/var.conf \
+	&& mv /data-template/etc/dirsrv/schema /usr/share/dirsrv/schema \
+	&& ln -s /usr/share/dirsrv/schema /data-template/etc/dirsrv/schema \
+	&& rm -f /data-template/var/lib/systemd/random-seed \
+	&& echo 1.1 > /etc/volume-version \
+	&& uuidgen > /data-template/build-id
 
 ENV container docker
 
 EXPOSE 53/udp 53 80 443 389 636 88 464 88/udp 464/udp 123/udp 7389 9443 9444 9445
 
-VOLUME [ "/tmp", "/run", "/data" ]
+VOLUME [ "/data" ]
 
-ENTRYPOINT [ "/usr/sbin/init-data" ]
-RUN uuidgen > /data-template/build-id
-
-LABEL INSTALL "docker run -ti -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /opt/ipa-data:/data:Z -h ipa.example.test ${NAME} exit-on-finished"
-LABEL RUN "docker run -ti -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /opt/ipa-data:/data:Z -h ipa.example.test ${NAME}"
+ENTRYPOINT [ "/sbin/init-data" ]

--- a/container-ipa.target
+++ b/container-ipa.target
@@ -1,6 +1,0 @@
-[Unit]
-Description=Minimal target for containerized FreeIPA server
-DefaultDependencies=false
-AllowIsolate=yes
-Requires=systemd-tmpfiles-setup.service systemd-journald.service dbus.service
-After=systemd-tmpfiles-setup.service systemd-journald.service dbus.service

--- a/init-data
+++ b/init-data
@@ -118,6 +118,6 @@ if [ -n "$IPA_SERVER_IP" ] ; then
 	echo "$IPA_SERVER_IP" > /run/ipa/ipa-server-ip
 fi
 
-exec /usr/sbin/init --show-status=false
+exec /usr/sbin/init
 
 exit 10

--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -23,10 +23,7 @@ mkdir -p /run/ipa
 trap mark_exit_code ERR EXIT
 
 set -e
-
-if ! [ -t /dev/stdout ] ; then
-	exec >> /var/log/ipa-server-configure-first.log 2>&1
-fi
+set -x
 
 echo "$(date) $0 $@"
 
@@ -164,6 +161,8 @@ else
 	else
 		if [ ! -f /data/ipa-server-install-options ] && [ -z "$PASSWORD" ] ; then
 			usage
+		elif [ ! -f /data/ipa-server-install-options ]; then
+			touch /data/ipa-server-install-options
 		fi
 		RUN_CMD="/usr/sbin/ipa-server-install"
 	fi
@@ -228,7 +227,9 @@ else
 				ln -sf /data$i $i
 			fi
 		done
-		cp /etc/volume-version /data/volume-version
+		if [ -f /etc/volume-verson ]; then
+			cp /etc/volume-version /data/volume-version
+		fi
 		while ! host -t A $HOSTNAME_FQDN > /dev/null ; do
 			sleep 1
 		done

--- a/ipa-server-configure-first.service
+++ b/ipa-server-configure-first.service
@@ -5,7 +5,7 @@ Description=Configure IPA server upon the first start
 Type=oneshot
 ExecStart=/usr/sbin/ipa-server-configure-first
 ExecStartPost=/usr/sbin/ipa-server-status-check
-FailureAction=poweroff
+#FailureAction=poweroff
 
 [Install]
-WantedBy=container-ipa.target
+WantedBy=multi-user.target

--- a/ipa-server-update-self-ip-address.service
+++ b/ipa-server-update-self-ip-address.service
@@ -9,4 +9,4 @@ Type=oneshot
 ExecStart=/usr/sbin/ipa-server-configure-first update-self-ip-address
 
 [Install]
-WantedBy=container-ipa.target
+WantedBy=mutil-user.target

--- a/ipa-server-upgrade.service
+++ b/ipa-server-upgrade.service
@@ -9,4 +9,4 @@ ExecStartPost=/usr/sbin/ipa-server-status-check
 FailureAction=poweroff
 
 [Install]
-WantedBy=container-ipa.target
+WantedBy=multi-user.target


### PR DESCRIPTION
I cleaned up some things if you are interested, because with `--tmpfs` added to docker you don't need them anymore.

then you can run with:
```
docker run --rm -it \
    --name docker-freeipa \
    --tmpfs /run --tmpfs /tmp \
    -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
    --cap-add SYS_ADMIN \
    --PASSWORD="your-secret-password" \
    -h ipa.example.test \
    freeipa
```