### PR TITLE
Do not export /tmp and /run as mount points

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ ENV container docker
 
 EXPOSE 53/udp 53 80 443 389 636 88 464 88/udp 464/udp 123/udp 7389 9443 9444 9445
 
-VOLUME [ "/tmp", "/run", "/data" ]
+VOLUME [ "/data" ]
 
 ENTRYPOINT [ "/usr/sbin/init-data" ]
 RUN uuidgen > /data-template/build-id


### PR DESCRIPTION
Having `/tmp` and `/run` directories under `VOLUME` command in `Dockerfile` makes use of tmpfs feature impossible.

After this change, it is possible to run freeipa container with /tmp and /run in tmpfs.

Is there any reason one should have persistent `/tmp` and `/run` directories in docker container when they are usually volatile in regular installations?

More info: https://docs.docker.com/engine/reference/run/#tmpfs-mount-tmpfs-filesystems