### PR TITLE
Dockerfile cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN dnf upgrade -y \
     && dnf clean all
 
 RUN groupadd -g 389 dirsrv \
-    && useradd -u 389 -g 389 \
+    && useradd -u 389 -g 389 -M \
         -c 'DS System User' \
         -d '/var/lib/dirsrv' \
         -s '/sbin/nologin' dirsrv \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ MAINTAINER Jan Pazdziora
 
 ENV container=docker
 
-RUN : > /etc/fstab
-
 RUN dnf install -y \
         bind \
         bind-dyndb-ldap \
@@ -20,6 +18,21 @@ RUN dnf upgrade -y \
         nss \
     && dnf clean all
 
+RUN groupadd -g 389 dirsrv \
+    && useradd -u 389 -g 389 \
+        -c 'DS System User' \
+        -d '/var/lib/dirsrv' \
+        -s '/sbin/nologin' dirsrv \
+    && groupadd -g 288 kdcproxy \
+    && useradd -u 288 -g 288 \
+        -c 'IPA KDC Proxy User' \
+        -d '/var/lib/kdcproxy' \
+        -s '/sbin/nologin' kdcproxy
+
+RUN /sbin/ldconfig -X \
+    && : > /etc/fstab \
+    && echo "LANG=C" > /etc/locale.conf
+
 # Workaround https://fedorahosted.org/spin-kickstarts/ticket/60
 RUN [ -L /etc/systemd/system/syslog.service ] && ! [ -f /etc/systemd/system/syslog.service ] && rm -f /etc/systemd/system/syslog.service
 
@@ -29,24 +42,16 @@ RUN echo '5a70f1f3db0608c156d5b6629d4cbc3b304fc045 /etc/systemd/system/sssd.serv
 RUN find /etc/systemd/system/* '!' -name '*.wants' | xargs rm -rvf
 RUN for i in basic.target sysinit.target network.service netconsole.service ; do rm -f /usr/lib/systemd/system/$i && ln -s /dev/null /usr/lib/systemd/system/$i ; done
 
-RUN echo LANG=C > /etc/locale.conf
-
-RUN /sbin/ldconfig -X
-
 COPY init-data ipa-server-configure-first ipa-server-status-check exit-with-status ipa-volume-upgrade-* /usr/sbin/
-RUN chmod -v +x /usr/sbin/init-data /usr/sbin/ipa-server-configure-first /usr/sbin/ipa-server-status-check /usr/sbin/exit-with-status /usr/sbin/ipa-volume-upgrade-*
 COPY container-ipa.target ipa-server-configure-first.service ipa-server-upgrade.service ipa-server-update-self-ip-address.service /usr/lib/systemd/system/
 RUN rmdir -v /etc/systemd/system/multi-user.target.wants \
-	&& mkdir /etc/systemd/system/container-ipa.target.wants \
-	&& ln -s /etc/systemd/system/container-ipa.target.wants /etc/systemd/system/multi-user.target.wants
+    && mkdir /etc/systemd/system/container-ipa.target.wants \
+    && ln -s /etc/systemd/system/container-ipa.target.wants /etc/systemd/system/multi-user.target.wants
 
-RUN systemctl set-default container-ipa.target
-RUN systemctl enable ipa-server-configure-first.service
+RUN systemctl set-default container-ipa.target \
+    && systemctl enable ipa-server-configure-first.service
 
-RUN mkdir -p /usr/lib/systemd/system/systemd-poweroff.service.d && ( echo '[Service]' ; echo 'ExecStartPre=/usr/bin/systemctl switch-root /usr /sbin/exit-with-status' ) > /usr/lib/systemd/system/systemd-poweroff.service.d/exit-via-chroot.conf
-
-RUN groupadd -g 389 dirsrv ; useradd -u 389 -g 389 -c 'DS System User' -d '/var/lib/dirsrv' --no-create-home -s '/sbin/nologin' dirsrv
-RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -d '/var/lib/kdcproxy' -s '/sbin/nologin' kdcproxy
+COPY exit-via-chroot.conf /usr/lib/systemd/system/systemd-poweroff.service.d/
 
 COPY volume-data-list volume-data-mv-list volume-data-autoupdate /etc/
 RUN set -e ; cd / ; mkdir /data-template ; cat /etc/volume-data-list | while read i ; do echo $i ; if [ -e $i ] ; then tar cf - .$i | ( cd /data-template && tar xf - ) ; fi ; mkdir -p $( dirname $i ) ; if [ "$i" == /var/log/ ] ; then mv /var/log /var/log-removed ; else rm -rf $i ; fi ; ln -sf /data${i%/} ${i%/} ; done
@@ -60,12 +65,13 @@ RUN echo 1.1 > /etc/volume-version
 
 RUN for i in /usr/lib/systemd/system/*-domainname.service ; do sed -i 's#^ExecStart=/#ExecStart=-/#' $i ; done
 
+RUN uuidgen > /data-template/build-id
+
 EXPOSE 53/udp 53 80 443 389 636 88 464 88/udp 464/udp 123/udp 7389 9443 9444 9445
 
 VOLUME [ "/tmp", "/run", "/data" ]
 
 ENTRYPOINT [ "/usr/sbin/init-data" ]
-RUN uuidgen > /data-template/build-id
 
 LABEL INSTALL "docker run -ti -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /opt/ipa-data:/data:Z -h ipa.example.test ${NAME} exit-on-finished"
 LABEL RUN "docker run -ti -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /opt/ipa-data:/data:Z -h ipa.example.test ${NAME}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,22 @@ FROM fedora:23
 
 MAINTAINER Jan Pazdziora
 
-RUN mkdir -p /run/lock && dnf install -y freeipa-server freeipa-server-dns bind bind-dyndb-ldap && dnf clean all
+ENV container=docker
+
+RUN : > /etc/fstab
+
+RUN dnf install -y \
+        bind \
+        bind-dyndb-ldap \
+        findutils \
+        freeipa-server \
+        freeipa-server-dns \
+    && dnf clean all
+
 # Workaround 1332456
-RUN dnf upgrade -y nss && dnf clean all
+RUN dnf upgrade -y \
+        nss \
+    && dnf clean all
 
 # Workaround https://fedorahosted.org/spin-kickstarts/ticket/60
 RUN [ -L /etc/systemd/system/syslog.service ] && ! [ -f /etc/systemd/system/syslog.service ] && rm -f /etc/systemd/system/syslog.service
@@ -46,10 +59,6 @@ RUN rm -f /data-template/var/lib/systemd/random-seed
 RUN echo 1.1 > /etc/volume-version
 
 RUN for i in /usr/lib/systemd/system/*-domainname.service ; do sed -i 's#^ExecStart=/#ExecStart=-/#' $i ; done
-
-RUN sed -i 's/^UUID=/# UUID=/' /etc/fstab
-
-ENV container docker
 
 EXPOSE 53/udp 53 80 443 389 636 88 464 88/udp 464/udp 123/udp 7389 9443 9444 9445
 

--- a/exit-via-chroot.conf
+++ b/exit-via-chroot.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/usr/bin/systemctl switch-root /usr /sbin/exit-with-status


### PR DESCRIPTION
I'd like to propose some changes in `Dockerfile` which ami at reducing overall number of layers the resulting image consists of and to enhance readability and maintainability of `Dockerfile`.

Short summary of proposed changes:

- Change ordering of instructions: e.g. `ENV` could go as close as possible to the top.
- Use different, more dockerish way of formatting of `dnf` command.
- I also removed `mkdir /run/lock` because it doesn't seem to be necessary any more (BTW it should be part of core file system if anything).
- I also replaced `sed -i 's/^UUID=/# UUID=/' /etc/fstab` with more simplistic `: > /etc/fstab` since we really doesn't care about content of `/etc/fstab`.
- I changed the way of how the content of `exit-via-chroot.conf` is generated: simply `COPY` existing file when image is built.

I'd like to propose more changes to `Dockerfile` and the other files in this project if you find this interesting.